### PR TITLE
Add scale policies on webserver

### DIFF
--- a/ec2/airflow/templates/user_data.sh
+++ b/ec2/airflow/templates/user_data.sh
@@ -4,6 +4,7 @@ set -ex
 
 exec > >(tee /var/log/user-data.log | logger -t user-data) 2>&1
 echo BEGIN
+BEGINTIME=$(date +%S)
 date "+%Y-%m-%d %H:%M:%S"
 
 yum install -y tree git python3 gcc postgresql-devel python3-devel.x86_64
@@ -79,3 +80,8 @@ systemctl enable airflow-webserver
 systemctl enable airflow-scheduler
 systemctl start airflow-webserver
 systemctl start airflow-scheduler
+
+date "+%Y-%m-%d %H:%M:%S"
+ENDTIME=$(date +%S)
+echo "Deployment took $(($ENDTIME - $BEGINTIME)) seconds"
+echo END

--- a/ec2/webserver/main.tf
+++ b/ec2/webserver/main.tf
@@ -44,6 +44,52 @@ resource "aws_autoscaling_group" "webserver" {
   }
 }
 
+resource "aws_autoscaling_policy" "scale_out_high_cpu" {
+  name                   = "${var.asg_name}-scale-out-high-cpu"
+  scaling_adjustment     = var.scale_out_adjustment
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = var.scale_cooldown
+  autoscaling_group_name = aws_autoscaling_group.webserver.name
+}
+
+resource "aws_cloudwatch_metric_alarm" "high_cpu_alarm" {
+  alarm_name          = "${var.asg_name}-high-cpu"
+  alarm_description   = "Scale out when CPU is too high"
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  dimensions          = { AutoScalingGroupName = aws_autoscaling_group.webserver.name }
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = var.high_cpu_eval_periods
+  period              = var.cpu_period
+  statistic           = var.cpu_statistic
+  threshold           = var.high_cpu_threshold
+  unit                = var.cpu_unit
+  alarm_actions       = [aws_autoscaling_policy.scale_out_high_cpu.arn]
+}
+
+resource "aws_autoscaling_policy" "scale_in_low_cpu" {
+  name                   = "${var.asg_name}-scale-in-low-cpu"
+  scaling_adjustment     = var.scale_in_adjustment
+  adjustment_type        = "ChangeInCapacity"
+  cooldown               = var.scale_cooldown
+  autoscaling_group_name = aws_autoscaling_group.webserver.name
+}
+
+resource "aws_cloudwatch_metric_alarm" "low_cpu_alarm" {
+  alarm_name          = "${var.asg_name}-low-cpu"
+  alarm_description   = "Scale in when CPU is low"
+  namespace           = "AWS/EC2"
+  metric_name         = "CPUUtilization"
+  dimensions          = { AutoScalingGroupName = aws_autoscaling_group.webserver.name }
+  comparison_operator = "LessThanThreshold"
+  evaluation_periods  = var.cpu_eval_periods
+  period              = var.cpu_period
+  statistic           = var.cpu_statistic
+  threshold           = var.low_cpu_threshold
+  unit                = var.cpu_unit
+  alarm_actions       = [aws_autoscaling_policy.scale_in_low_cpu.arn]
+}
+
 resource "aws_lb" "web_lb" {
   name_prefix = var.lb_name_prefix
   security_groups = [
@@ -101,6 +147,7 @@ resource "aws_lb_listener" "https" {
     target_group_arn = aws_lb_target_group.webserver.arn
   }
 }
+
 
 data "terraform_remote_state" "iam" {
   backend = "s3"

--- a/ec2/webserver/main.tf
+++ b/ec2/webserver/main.tf
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "low_cpu_alarm" {
   metric_name         = "CPUUtilization"
   dimensions          = { AutoScalingGroupName = aws_autoscaling_group.webserver.name }
   comparison_operator = "LessThanThreshold"
-  evaluation_periods  = var.cpu_eval_periods
+  evaluation_periods  = var.low_cpu_eval_periods
   period              = var.cpu_period
   statistic           = var.cpu_statistic
   threshold           = var.low_cpu_threshold

--- a/ec2/webserver/variables.tf
+++ b/ec2/webserver/variables.tf
@@ -133,3 +133,63 @@ variable "domain_name" {
   description = "Name of the web domain to use for the server"
   type        = string
 }
+
+variable "scale_out_adjustment" {
+  description = "Number of instances by which to scale out"
+  type        = number
+  default     = 1
+}
+
+variable "scale_in_adjustment" {
+  description = "Number of instances by which to scale in"
+  type        = number
+  default     = -1
+}
+
+variable "scale_cooldown" {
+  description = "Number of seconds before next scaling can start"
+  type        = number
+  default     = 300
+}
+
+variable "high_cpu_eval_periods" {
+  description = "Number of periods over which CPU is compared to high threshold"
+  type        = number
+  default     = 1
+}
+
+variable "low_cpu_eval_periods" {
+  description = "Number of periods over which CPU is compared to low threshold"
+  type        = number
+  default     = 3
+}
+
+variable "cpu_period" {
+  description = "Number of seconds over which statistic is applied to CPU utilization"
+  type        = number
+  default     = 300
+}
+
+variable "cpu_statistic" {
+  description = "Statistic to apply to CPU utilization metric"
+  type        = string
+  default     = "Average"
+}
+
+variable "high_cpu_threshold" {
+  description = "Threshold over which CPU utilization requires scale out"
+  type        = number
+  default     = 80
+}
+
+variable "low_cpu_threshold" {
+  description = "Threshold under which CPU utilization requires scale in"
+  type        = number
+  default     = 20
+}
+
+variable "cpu_unit" {
+  description = "Unit of measure of CPU utilization"
+  type        = string
+  default     = "Percent"
+}


### PR DESCRIPTION
We add scale in and out policies on the webserver autoscaling group:
scale out by 1 instance when CPU utilization stays above 80% for 5
minutes and scale in by 1 instance when CPU utilizations stays below 20%
for 15 minutes. We provide variables to adjust these parameters.

We also add a small update to Airflow user data to calculate deployment
time.